### PR TITLE
 В компоненте для выполнения сетевых запросов поиск вакансий

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/data/general/impl/VacanciesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/general/impl/VacanciesRepositoryImpl.kt
@@ -37,7 +37,7 @@ class VacanciesRepositoryImpl @Inject constructor(
         } else if (response.resultCode >= HTTP_CLIENT_ERROR) {
             ResponseState.ServerError
         } else {
-            ResponseState.NetworkError
+            ResponseState.NetworkError(false)
         }
     }
 
@@ -52,7 +52,7 @@ class VacanciesRepositoryImpl @Inject constructor(
         ) {
             ResponseState.ServerError
         } else {
-            ResponseState.NetworkError
+            ResponseState.NetworkError(false)
         }
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
@@ -2,6 +2,8 @@ package ru.practicum.android.diploma.data.network
 
 import android.content.Context
 import android.net.ConnectivityManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import retrofit2.HttpException
 import java.io.IOException
 import javax.inject.Inject
@@ -20,34 +22,38 @@ class RetrofitNetworkClient @Inject constructor(
         if (!isOnline(context)) return Response().apply { resultCode = -1 }
 
         @Suppress("SwallowedException")
-        return try {
-            val resp = headHunterService.vacancies(query)
-            resp.apply {
-                resultCode = HTTP_OK
+        return withContext(Dispatchers.IO) {
+            try {
+                val resp = headHunterService.vacancies(query)
+                resp.apply {
+                    resultCode = HTTP_OK
+                }
+            } catch (e: IOException) {
+                Response().apply {
+                    resultCode = HTTP_ERROR
+                }
+            } catch (e: HttpException) {
+                Response().apply { resultCode = e.code() }
             }
-        } catch (e: IOException) {
-            Response().apply {
-                resultCode = HTTP_ERROR
-            }
-        } catch (e: HttpException) {
-            Response().apply { resultCode = e.code() }
         }
     }
 
     override suspend fun doRequestById(id: String): Response {
         if (!isOnline(context)) return Response().apply { resultCode = -1 }
         @Suppress("SwallowedException")
-        return try {
-            val resp = headHunterService.getVacancyById(id)
-            resp.apply {
-                resultCode = HTTP_OK
+        return withContext(Dispatchers.IO) {
+            try {
+                val resp = headHunterService.getVacancyById(id)
+                resp.apply {
+                    resultCode = HTTP_OK
+                }
+            } catch (e: IOException) {
+                Response().apply {
+                    resultCode = HTTP_ERROR
+                }
+            } catch (e: HttpException) {
+                Response().apply { resultCode = e.code() }
             }
-        } catch (e: IOException) {
-            Response().apply {
-                resultCode = HTTP_ERROR
-            }
-        } catch (e: HttpException) {
-            Response().apply { resultCode = e.code() }
         }
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/domain/general/models/ResponseState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/general/models/ResponseState.kt
@@ -9,7 +9,7 @@ sealed class ResponseState {
     data object Empty : ResponseState()
     data class ContentVacanciesList(val listVacancy: List<Vacancy>, val found: Int, val pages: Int) : ResponseState()
     data class ContentVacancyDetail(val vacancyDetail: VacancyDetail) : ResponseState()
-    data object NetworkError : ResponseState()
+    data class NetworkError(val isPagination: Boolean) : ResponseState()
     data object ServerError : ResponseState()
     data class Loading(val isPagination: Boolean) : ResponseState()
 

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/general/fragment/GeneralFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/general/fragment/GeneralFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -51,7 +52,7 @@ class GeneralFragment : Fragment(R.layout.fragment_general) {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentGeneralBinding.inflate(layoutInflater)
         return binding.root
     }
@@ -146,8 +147,13 @@ class GeneralFragment : Fragment(R.layout.fragment_general) {
                 binding.srcText.setText(R.string.server_error)
             }
 
-            ResponseState.NetworkError -> {
+            ResponseState.NetworkError(false) -> {
                 binding.srcText.setText(R.string.no_internet)
+            }
+
+            ResponseState.NetworkError(true) -> {
+                binding.src.isVisible = false
+                Toast.makeText(requireContext(), "Ошибка соединения", Toast.LENGTH_SHORT).show()
             }
 
             else -> {
@@ -161,6 +167,7 @@ class GeneralFragment : Fragment(R.layout.fragment_general) {
         binding.vacanciesRv.isVisible = when (state) {
             is ResponseState.Loading -> state.isPagination
             is ResponseState.ContentVacanciesList -> true
+            is ResponseState.NetworkError -> true
             else -> false
         }
         binding.src.visibleOrGone(state !is ResponseState.Loading && state !is ResponseState.ContentVacanciesList)
@@ -178,7 +185,7 @@ class GeneralFragment : Fragment(R.layout.fragment_general) {
                 R.drawable.state_image_server_error_search
             }
 
-            ResponseState.NetworkError -> {
+            ResponseState.NetworkError(false) -> {
                 R.drawable.state_image_no_internet
             }
 

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/general/viewmodel/GeneralViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/general/viewmodel/GeneralViewModel.kt
@@ -21,6 +21,7 @@ class GeneralViewModel @Inject constructor(
     fun observeUi(): LiveData<ResponseState> = state
 
     private var isNextPageLoading = false
+    private var listCount: Int = 1
 
     private var query: String? = null
         set(value) {
@@ -44,8 +45,7 @@ class GeneralViewModel @Inject constructor(
     private fun makeSearchRequest(query: String, page: Int, isPagination: Boolean) {
         state.postValue(ResponseState.Loading(isPagination))
         viewModelScope.launch {
-            val response = searchVacanciesUseCase(query, page)
-            when (response) {
+            when (val response = searchVacanciesUseCase(query, page)) {
                 is ResponseState.ContentVacanciesList -> {
                     maxPages = response.pages
                     currentListVacancies = if (isPagination) {
@@ -62,6 +62,8 @@ class GeneralViewModel @Inject constructor(
                         )
                     )
                 }
+
+                is ResponseState.NetworkError -> state.postValue(ResponseState.NetworkError(isPagination))
 
                 is ResponseState.Loading -> state.postValue(ResponseState.Loading(isPagination))
                 else -> {
@@ -93,11 +95,3 @@ class GeneralViewModel @Inject constructor(
         const val PAG_COUNT: Int = 20
     }
 }
-
-data class ViewState(
-    val vacancies: List<Vacancy> = emptyList(),
-    val status: ResponseState = ResponseState.Start,
-    val found: Int = 0,
-    val isLoading: Boolean = false,
-    val vacanciesProgress: Boolean = false
-)


### PR DESCRIPTION
Контекст переключается в компоненте для выполнения сетевых запросов.
В процессе загрузки новой страницы контента отсутствовал интернет или произошла ошибка, то индикатор загрузки должен исчезнуть и пользователь должен увидеть стандартный Toast с сообщением